### PR TITLE
Prepare registry and menu follow-up fixes

### DIFF
--- a/install_scripts/OpFamRegistry/fam_script_callbacks.py
+++ b/install_scripts/OpFamRegistry/fam_script_callbacks.py
@@ -56,7 +56,8 @@ def cook(scriptOp):
         scriptOp.copy(scriptOp.inputs[0])
         return
 
-    if 'name' not in [familyOps[0, c].val for c in range(familyOps.numCols)]:
+    col_names_pre = [familyOps[0, c].val for c in range(familyOps.numCols)]
+    if 'name' not in col_names_pre or 'label' not in col_names_pre or 'type' not in col_names_pre:
         scriptOp.copy(scriptOp.inputs[0])
         return
 
@@ -103,8 +104,9 @@ def cook(scriptOp):
             if not familyOps or familyOps.numRows < 2 or familyOps.numCols == 0:
                 continue
 
-            # Check 'name' column exists
-            if 'name' not in [familyOps[0, c].val for c in range(familyOps.numCols)]:
+            # Check required columns exist
+            col_names = [familyOps[0, c].val for c in range(familyOps.numCols)]
+            if 'name' not in col_names or 'label' not in col_names or 'type' not in col_names:
                 continue
             
             group_table = installer.op('group_mapping')

--- a/install_scripts/OpFamRegistry/src/GlobalUIInjector.py
+++ b/install_scripts/OpFamRegistry/src/GlobalUIInjector.py
@@ -463,8 +463,6 @@ elif(source == 'input' and ({compatible_check})):
 		if not families_op:
 			return
 
-		families_op.bypass = False
-		
 		inject_op = nodeTable.op(inject_op_name)
 		if not inject_op:
 			original_input = families_op.inputs[0] if families_op.inputs else None
@@ -482,8 +480,8 @@ elif(source == 'input' and ({compatible_check})):
 		inject_op.nodeX = families_op.nodeX - 150
 		inject_op.nodeY = families_op.nodeY
 
-		families_op.cook(force=True)
 		inject_op.cook(force=True)
+		families_op.cook(force=True)
 
 	def _setup_global_panel_execute(self, force=True):
 		"""Deploy single opfam_panel_execute to menu_op."""

--- a/install_scripts/OpFamRegistry/src/OpManager.py
+++ b/install_scripts/OpFamRegistry/src/OpManager.py
@@ -443,7 +443,7 @@ class OpManager:
 					tox_entries.append((name.lower(), os.path.join(operators_folder, item), version, operators_folder))
 
 		if not tox_entries:
-			print(f"deployManifestsToDisk: no .tox files under {operators_folder}")
+			debug(f"deployManifestsToDisk: no .tox files under {operators_folder}")
 			return 0
 
 		count = 0
@@ -582,10 +582,7 @@ class OpManager:
 		fam_name = OpInfo.get('op_fam')
 		op_type = OpInfo.get('op_type')
 		
-		debug(f'about to register {Shortcuts} for {_op}')
-
 		for _shortcut, _action in Shortcuts.items():
-			debug(f'attempting to register shortcut {_shortcut} for {_op}')
 			self.registry.ShortcutManager.registerOpShortcut(fam_name, op_type, _shortcut, _action)
 
 		return
@@ -612,12 +609,8 @@ class OpManager:
 
 	def _handle_attributes(self, family_owner, _op, is_file_based=False, OpInfo=None):
 		op_color = OpInfo.get('op_color') if OpInfo else None
-		debug(f"[_handle_attributes] op={_op.path} is_file_based={is_file_based} op_color={op_color} OpInfo_keys={list(OpInfo.keys()) if OpInfo else None} color_before={_op.color}")
 		if is_file_based or op_color:
 			apply_family_color(family_owner, _op, op_color=op_color)
-			debug(f"[_handle_attributes] color_after_apply={_op.color}")
-		else:
-			debug(f"[_handle_attributes] SKIPPED apply_family_color — not file_based and no op_color")
 
 		_op.allowCooking = True
 		_op.bypass = False

--- a/install_scripts/installer.py
+++ b/install_scripts/installer.py
@@ -200,6 +200,24 @@ class OpFamCreateExt:
                     if template:
                         sys_registry = sys.copy(template, name='TDFamRegistry')
 
+                if sys_registry and not reg_file_path:
+                    try:
+                        new_version = sys_registry.par.Version.eval() if hasattr(sys_registry.par, 'Version') else None
+                        if new_version:
+                            if not folder_exists:
+                                os.makedirs(global_file_registry_folder, exist_ok=True)
+                            for f in existing_files:
+                                try:
+                                    os.remove(global_file_registry_folder + '/' + f)
+                                except OSError:
+                                    pass
+                            new_tox_path = f"{global_file_registry_folder}/TDFamRegistry_{new_version}.tox"
+                            sys_registry.save(new_tox_path)
+                            sys_registry.par.externaltox = new_tox_path
+                            sys_registry.par.enableexternaltox = True
+                    except Exception as e:
+                        print(f"TDFam: Warning — could not persist upgraded registry to palette: {e}")
+
                 if sys_registry:
                     sys_registry.allowCooking = True
                     sys_registry.nodeX = sys.op('TDDialogs').nodeX
@@ -393,6 +411,9 @@ class OpFamCreateExt:
         return self.fam_registry.GetMasterOps(self.FamilyName.val)
 
     def _refresh_folder(self):
+        self._refresh_registry_ref()
+        if not self.fam_registry:
+            return
         self.fam_registry.FileManager.refresh_cache(self.FamilyName.val, self.operators_folder)
 
         fam_create = self.ownerComp.op('fam_create')


### PR DESCRIPTION
## Summary
- harden OP Create family table handling by requiring expected columns before processing
- adjust global family DAT setup so the injected DAT cooks before the original families DAT
- quiet noisy manifest/shortcut/color debug output
- persist copied registry templates to the user palette and refresh stale registry refs before folder refresh

## Notes
- script-only follow-up on top of PR #100 / dev
- no release tox files are updated in this PR

## Verification
- git diff --check
- python -m py_compile install_scripts/OpFamRegistry/fam_script_callbacks.py install_scripts/OpFamRegistry/src/GlobalUIInjector.py install_scripts/OpFamRegistry/src/OpManager.py install_scripts/installer.py