### PR TITLE
perf(registry): resolve embedded operators from a per-family manifest…

### DIFF
--- a/install_scripts/OpFamRegistry/OpFamRegistryExt.py
+++ b/install_scripts/OpFamRegistry/OpFamRegistryExt.py
@@ -746,6 +746,10 @@ class OpFamRegistryExt:
 				op_type, op_name, op_label, op_version, fam_version,
 				op_fam, group, source, os_compatible
 		"""
+		# Manifest index is scoped to this call: rebuilt once here, reused by every
+		# get_operator_source() lookup below, dropped on exit. No staleness surface.
+		self.FileManager.invalidate_manifest_index(family_name)
+
 		installer = self.GetFamilyExt(family_name)
 		if not installer:
 			return {}

--- a/install_scripts/OpFamRegistry/src/FileManager.py
+++ b/install_scripts/OpFamRegistry/src/FileManager.py
@@ -30,6 +30,7 @@ class FileManager:
 		self.ownerComp = ownerComp
 		self.registry = registry
 		self._search_words_cache = {}  # {family_name: {op_type_lower: [words]}}
+		self._manifest_index_cache = {}  # {family_name: {op_type_lower: [master_op, ...]}}
 
 	def refresh_cache(self, family_name, operators_folder):
 		"""
@@ -234,6 +235,53 @@ class FileManager:
 		except:
 			return None
 
+	def _get_manifest_index(self, family_name):
+		"""Return {op_type_lower: [master_op, ...]} for the family's embedded masters.
+
+		One pass over operators_comp, cached per family. Replaces the per-lookup deep
+		manifest scan in get_operator_source(), which parsed every manifest for every
+		lookup and was therefore O(masters^2) in JSON parses per cook.
+		"""
+		cached = self._manifest_index_cache.get(family_name)
+		if cached is not None:
+			return cached
+
+		index = {}
+		installer = self.registry.GetFamilyExt(family_name)
+		custom_ops = installer.operators_comp if installer else None
+		if custom_ops:
+			type_regex = re.compile(r'<TYPE:(.*)>')
+			for manifest in custom_ops.findChildren(tags=['<MANIFEST>'], maxDepth=2):
+				master = manifest.parent()
+				if not master or master == custom_ops:
+					continue
+				op_type = None
+				if opinfo_dat := manifest.op('OpInfo'):
+					try:
+						op_type = json.loads(opinfo_dat.text).get('op_type')
+					except Exception:
+						op_type = None
+				if op_type:
+					op_type = op_type.replace(family_name, '')
+				else:
+					for tag in manifest.tags:
+						if match := type_regex.match(tag):
+							op_type = match.group(1)
+							break
+				if not op_type:
+					continue
+				index.setdefault(op_type.strip().lower(), []).append(master)
+
+		self._manifest_index_cache[family_name] = index
+		return index
+
+	def invalidate_manifest_index(self, family_name=None):
+		"""Drop the cached manifest index for a family (or all families)."""
+		if family_name is None:
+			self._manifest_index_cache.clear()
+		else:
+			self._manifest_index_cache.pop(family_name, None)
+
 	def get_operator_source(self, family_name, lookup_name):
 		"""
 		Get operator source - embedded or file-based.
@@ -275,22 +323,10 @@ class FileManager:
 					return (version, trailing)
 				return max(ops, key=_score) if ops else None
 
-			# Fast tag lookup — may return multiple masters with the same op_type; pick highest-numbered.
-			manifested_ops = custom_ops.findChildren(tags=["<MANIFEST>", f'<FAM:{family_name}>', f'<TYPE:{lookup_name}>'], maxDepth=1)
+			# Indexed manifest lookup — built once per family, reused for every lookup
+			# in the cook. May return multiple masters with the same op_type; pick highest.
+			manifested_ops = self._get_manifest_index(family_name).get(lookup_name.strip().lower(), [])
 			manifested = _pick_highest(manifested_ops) if manifested_ops else None
-
-			if not manifested:
-				# Deep manifest scan — collect all matches, then pick highest-numbered.
-				manifest_candidates = []
-				for _manifest in custom_ops.findChildren(tags=["<MANIFEST>"], maxDepth=2):
-					if _opInfo := _manifest.op('OpInfo'):
-						import json
-						_opInfo_dict = json.loads(_opInfo.text)
-						if _opType := _opInfo_dict.get('op_type'):
-							_opType = _opType.replace(family_name, '')
-							if _opType == lookup_name:
-								manifest_candidates.append(_manifest.parent())
-				manifested = _pick_highest(manifest_candidates) if manifest_candidates else None
 
 			if not manifested:
 				# Name-based fallback — also covers masters named 'foo1' for op_type 'foo'.


### PR DESCRIPTION
… index

GetMasterOps() calls get_operator_source() once per operator, and each call falls back to a deep manifest scan that parses every manifest's OpInfo JSON, so one fam_create cook costs O(masters^2) JSON parses.

The fast tag lookup never hits: it queries maxDepth=1, but _tag_op() writes <MANIFEST>/<FAM:>/<TYPE:> onto each master's FamManifest child at depth 2. Depth alone is not the fix - findChildren(allTags) defaults to False, so a deeper query would OR-match every manifest and resolve every lookup to the same master, and <TYPE:> tags keep their case while lookups are lowercased.

Replaces the tag query and the deep scan with one indexed pass per family ({op_type_lower: [master, ...]}), invalidated at the top of GetMasterOps so it is built once per call and reused by every lookup inside it. The name-based fallback is unchanged.

TouchDesigner 2025.32820, 133 masters:

  GetMasterOps json.loads  18,088 -> 532
  GetMasterOps              ~89ms -> ~3.7ms
  fam_create cook           ~97ms -> ~6.5ms
  menu view switch       96-101ms -> 7-9ms

GetMasterOps returns 133 rows before and after with an identical fingerprint (op_name, op_version, op_label per op_type): 0 missing, 0 added, 0 changed.